### PR TITLE
Added PT1 Element to PID1 and PID2

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -171,6 +171,7 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->D8[PIDVEL] = 1;
 
     pidProfile->yaw_p_limit = YAW_P_LIMIT_MAX;
+    pidProfile->main_cut_hz = MAIN_CUT_HZ;
 
     pidProfile->P_f[ROLL] = 2.5f;     // new PID with preliminary defaults test carefully
     pidProfile->I_f[ROLL] = 0.6f;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -19,7 +19,7 @@
 
 #define GYRO_I_MAX 256                      // Gyro I limiter
 #define RCconstPI   0.159154943092f         // 0.5f / M_PI;
-#define MAIN_CUT_HZ 12.0f                   // (default 12Hz, Range 1-50Hz)
+#define MAIN_CUT_HZ 0.0f                    // (default Disabled, Range 1-50Hz) Used for PT1 element in PID1, PID2 and PID5
 #define OLD_YAW 0                           // [0/1] 0 = MultiWii 2.3 yaw, 1 = older yaw.
 #define YAW_P_LIMIT_MIN 100                 // Maximum value for yaw P limiter
 #define YAW_P_LIMIT_MAX 500                 // Maximum value for yaw P limiter
@@ -55,6 +55,7 @@ typedef struct pidProfile_s {
     float H_level;
     uint8_t H_sensitivity;
     uint16_t yaw_p_limit;                   // set P term limit (fixed value was 300)
+    uint8_t main_cut_hz;                      // (default 17Hz, Range 1-50Hz) Used for PT1 element in PID1, PID2 and PID5
 } pidProfile_t;
 
 #define DEGREES_TO_DECIDEGREES(angle) (angle * 10)

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -448,6 +448,7 @@ const clivalue_t valueTable[] = {
     { "d_vel",                      VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.D8[PIDVEL], 0, 200 },
 
     { "yaw_p_limit",                VAR_UINT16 | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.yaw_p_limit, YAW_P_LIMIT_MIN, YAW_P_LIMIT_MAX },
+	{ "main_cut_hz",                VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.main_cut_hz, 0, 50 },
 
 #ifdef BLACKBOX
     { "blackbox_rate_num",          VAR_UINT8  | MASTER_VALUE,  &masterConfig.blackbox_rate_num, 1, 32 },


### PR DESCRIPTION
Shared CUT value for PID1, PID2 and PID5

Put back moving average

This is actually how I have been testing it lately. For some reason PID1
jusst needs this moving average for the best result

Added moving average PID2

PT1 main_cut_hz configurable in cli (default=0 disabled)

Removed some code and changed description

PID3 added PT1 filter

Harakiri MAIN_CUT_HZ fix (was broken)
